### PR TITLE
Mask load from disk

### DIFF
--- a/dpat/types.py
+++ b/dpat/types.py
@@ -1,9 +1,11 @@
 """Type stubs."""
 
-from typing import Any, Protocol, Sized
+from typing import Any, Literal, Protocol, Sized
 
 from torch import nn
 from torch.utils.data import Dataset
+
+MaskFactory = Literal["no_mask", "load_from_disk"]
 
 
 class SizedDataset(Sized, Dataset):

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.10
   - pre-commit
   - pyvips


### PR DESCRIPTION
Fix #12 

https://github.com/siemdejong/dlup/commit/8de3c5689a1cd48cff77a0648dae6f918eae4457 allows for entropy masking, which is useful for darkfield HHG images.

The entropy masking dlup commit is not _yet_ merged upstream, but `pyproject.toml` makes sure `dlup` is installed from the `entropy_masker` `dlup` fork.